### PR TITLE
Use `web_time` for `SystemTime::now` to support WASM runtimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 ctor = "0.1.20"
 coarsetime = "0.1"
+web-time = "1.0"
 
 [features]
 atomic = []

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -2,8 +2,9 @@
 
 use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// A measurement of a monotonically nondecreasing clock. Similar to
 /// [`std::time::Instant`](std::time::Instant) but is faster and more


### PR DESCRIPTION
No need for any conditional configuration, as it's already done in `web-time`:

> At the same time the library will simply re-export [std::time](https://doc.rust-lang.org/stable/std/time/) when not using the wasm32-unknown-unknown target and will not pull in any dependencies.

